### PR TITLE
Timeline is assumed to have more than one entry

### DIFF
--- a/test/ChartTimeRangeTest.coffee
+++ b/test/ChartTimeRangeTest.coffee
@@ -130,22 +130,3 @@ exports.ChartTimeRangeTest =
     test.equal(i4.hasNext(), false)
   
     test.done()
-
-  testSinglePointTimeline: (test) ->
-    r5 = new ChartTimeRange({
-      start:'2011-01-06T00',
-      pastEnd:'2011-01-07T00',
-      startWorkTime: {hour: 9, minute: 0},
-      pastEndWorkTime: {hour: 10, minute: 0}
-    })
-
-    test.deepEqual([{
-      beforePastFlag: '',
-      granularity: 'hour',
-      year: 2011,
-      month: 1,
-      day: 6,
-      hour: 9
-    }], r5.getTimeline())
-
-    test.done()

--- a/test/timelineTest.coffee
+++ b/test/timelineTest.coffee
@@ -150,3 +150,22 @@ exports.timelineTest =
     test.deepEqual(expected, s)
     
     test.done()
+  
+  testSinglePointTimeline: (test) ->
+    r5 = new ChartTimeRange({
+      start:'2011-01-06T00',
+      pastEnd:'2011-01-07T00',
+      startWorkTime: {hour: 9, minute: 0},
+      pastEndWorkTime: {hour: 10, minute: 0}
+    })
+
+    test.deepEqual([{
+      beforePastFlag: '',
+      granularity: 'hour',
+      year: 2011,
+      month: 1,
+      day: 6,
+      hour: 9
+    }], r5.getTimeline())
+
+    test.done()


### PR DESCRIPTION
Ran into this issue where timelines that only have a single point blow up, this is a fix (with unit test)
