### PR TITLE
Add JSON2 as a requirement for IE7 json support

### DIFF
--- a/lumenize.coffee
+++ b/lumenize.coffee
@@ -25,6 +25,8 @@ And last, additional functionality is provided by:
   * Lumenize.utils - utility methods used by the rest of Lumenize (type, clone, array/object functions, etc.)
 
 ###
+JSON = require('JSON2')
+
 tzTime = require('tztime')
 exports.Time = tzTime.Time
 exports.TimelineIterator = tzTime.TimelineIterator

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "coffee-script": "1.4.x",
     "tztime": "~0.6.1",
-    "jsduckify": "~0.2.2"
+    "jsduckify": "~0.2.2",
+    "JSON2": "0.1.0"
   },
   "devDependencies": {
     "coffeedoctest": "0.4.x",


### PR DESCRIPTION
Added JSON2 as a requirement that will allow Lumenize to be used in IE7. Won't replace the native JSON support of a browser if it has it.
